### PR TITLE
Explosive trap and Snake Trap add in SpellMgr.cpp

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3080,6 +3080,19 @@ void SpellMgr::LoadSpellCustomAttr()
         case 30834: // Infernal Relay
             spellInfo->AttributesEx2 |= SPELL_ATTR_EX2_IGNORE_LOS;
             break;
+        // Explosive Trap - fix initial dmg and proc
+        case 13812: // rank 1
+        case 14314: // rank 2
+        case 14315: // rank 3
+        case 27026: // rank 4
+            spellInfo->EffectImplicitTargetA[0] = TARGET_UNIT_TARGET_ENEMY;
+            break;
+        // Frost Trap & Snake Trap - fix proc
+        case 13810:
+        case 45145:
+            spellInfo->Effect[2] = SPELL_EFFECT_DUMMY;
+            spellInfo->EffectImplicitTargetA[2] = TARGET_UNIT_TARGET_ENEMY;
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Explosive trap - fixed the initial damage and proc - first effect had no target
Frost Trap and Snake Trap - added one special effect to allow specific target and thus proccing
[a source](https://bitbucket.org/oregon/oregoncore/commits/8c3d369927d428c76c5f118e9429779100db97f4)
It can perhaps solve this problem: [37 issue](https://github.com/robinsch/TBCPvP/issues/37)